### PR TITLE
Feat/handle more elements

### DIFF
--- a/mock/sample.md
+++ b/mock/sample.md
@@ -1,62 +1,21 @@
 ### here is a sample
 
+# does
+
+## this
+
+### work
+
+#### as
+
+##### expected
+
+- does this
+  - work as expected
+
+1. does this
+   - work
+     - as
+       - expected
+
 it has some paragraphs with<!--sneaky--> html comments within em
-
-TESTING
-
-testing ttesting
-
-hi there ha ha ha
-hi there ha ha ha
-hi there ha ha ha
-hi there ha ha ha
-hi there ha ha ha
-hi there ha ha ha
-hi there ha ha ha
-hi there ha ha ha
-
-hi there ha ha ha
-
-
-
-
-
-
-
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-yay yay yay yay yay yay
-
-hi there ha ha ha
-hi there ha ha ha
-hi there ha ha ha
-hi there ha ha ha
-hi there ha ha ha
-hi there ha ha ha
-hi there ha ha ha
-hi there ha ha ha
-<!-- here are some more comments -->
-<!-- here are some more comments -->

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Meet word count goals with markdown and node",
   "main": "index.js",
   "scripts": {
+    "dev": "node src/index.js",
     "build": "webpack"
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,25 @@ function toHtml(markdown) {
 
 function countHTMLWords(html) {
   const dom = new JSDOM(html);
-  const textContent = Array.from(dom.window.document.querySelectorAll('p'))
+  const elements = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'ul', 'ol'];
+
+  const textContent = elements
+    .map((el) =>
+      Array.from(dom.window.document.querySelectorAll(el)).filter((node) => {
+        if (['OL', 'UL'].includes(node.tagName)) {
+          let parent = node.parentElement;
+          while (parent) {
+            if (['OL', 'UL', 'LI'].includes(parent.tagName)) {
+              return false;
+            }
+            parent = parent.parentElement;
+          }
+          return true;
+        }
+        return true;
+      }),
+    )
+    .flat()
     .map((node) => node.textContent)
     .join(' ');
   return countWords(textContent);


### PR DESCRIPTION
just `p` tags was too restrictive! grab more tags, which, for `ol` and `ul` tags, means implementing some logic to just grab the root tag and get its text content, to avoid double counting for nested lists.